### PR TITLE
Deduplicate code, Solve() is everywhere

### DIFF
--- a/cmd/solve.go
+++ b/cmd/solve.go
@@ -8,6 +8,7 @@ import (
 	"github.com/somebadcode/adventofcode2019/pkg/day3"
 	"github.com/somebadcode/adventofcode2019/pkg/day4"
 	"github.com/spf13/viper"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ import (
 func solve(path string, config *viper.Viper, logger *log.Logger) error {
 	wg := sync.WaitGroup{}
 
-	solvers := []solver.Solver{
+	solvers := []solver.Parts{
 		day1.New(config.Sub("day1")),
 		day2.New(config.Sub("day2")),
 		day3.New(config.Sub("day3")),
@@ -31,7 +32,7 @@ func solve(path string, config *viper.Viper, logger *log.Logger) error {
 		}
 
 		wg.Add(1)
-		go func(s solver.Solver, day int, f *os.File) {
+		go func(s solver.Parts, day int, f *os.File) {
 
 			defer wg.Done()
 			defer func() {
@@ -39,9 +40,15 @@ func solve(path string, config *viper.Viper, logger *log.Logger) error {
 					fmt.Println(err)
 				}
 			}()
-			results := s.Solve(f)
+			p1 := s.PartOne(f)
+			_, err := f.Seek(0, io.SeekStart)
+			if err != nil {
+				logger.Printf("Day %d\tError: %s\n", day, err)
+				return
+			}
+			p2 := s.PartTwo(f)
 
-			logger.Printf("Day %d\tPart 1: %s\n\tPart 2: %s\n", day, results[0], results[1])
+			logger.Printf("Day %d\tPart 1: %s\n\tPart 2: %s\n", day, p1, p2)
 		}(s, i+1, file)
 	}
 

--- a/internal/solver/solver.go
+++ b/internal/solver/solver.go
@@ -2,6 +2,7 @@ package solver
 
 import "io"
 
-type Solver interface {
-	Solve(r io.ReadSeeker) []string
+type Parts interface {
+	PartOne(r io.ReadSeeker) string
+	PartTwo(r io.ReadSeeker) string
 }

--- a/pkg/day1/day1.go
+++ b/pkg/day1/day1.go
@@ -12,21 +12,10 @@ type Solver struct {
 	config *viper.Viper
 }
 
-func New(config *viper.Viper) solver.Solver {
+func New(config *viper.Viper) solver.Parts {
 	return &Solver{
 		config: config,
 	}
-}
-
-func (s *Solver) Solve(r io.ReadSeeker) []string {
-	solution := s.PartOne(r)
-
-	_, err := r.Seek(0, io.SeekStart)
-	if err != nil {
-		return []string{err.Error(), ""}
-	}
-
-	return []string{solution, s.PartTwo(r)}
 }
 
 func (s Solver) PartOne(r io.ReadSeeker) string {

--- a/pkg/day1/day1_test.go
+++ b/pkg/day1/day1_test.go
@@ -1,7 +1,6 @@
 package day1
 
 import (
-	"github.com/somebadcode/adventofcode2019/internal/testdatafromfile"
 	"github.com/somebadcode/adventofcode2019/pkg/badreadseeker"
 	"github.com/spf13/viper"
 	"io"
@@ -150,50 +149,6 @@ func TestSolver_PartTwo(t *testing.T) {
 			}
 			if got := s.PartTwo(tt.args.r); got != tt.want {
 				t.Errorf("PartTwo() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestSolver_Solve(t *testing.T) {
-	type fields struct {
-		config *viper.Viper
-	}
-	type args struct {
-		r io.ReadSeeker
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   []string
-	}{
-		{
-			args: args{
-				r: strings.NewReader("100756"),
-			},
-			want: []string{"33583", "50346"},
-		},
-		{
-			args: args{
-				r: badreadseeker.New(strings.NewReader("100756"), io.ErrShortBuffer, badreadseeker.Seek),
-			},
-			want: []string{io.ErrShortBuffer.Error(), ""},
-		},
-		{
-			args: args{
-				r: testdatafromfile.From("day1.txt"),
-			},
-			want: []string{"3167282", "4748063"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Solver{
-				config: tt.fields.config,
-			}
-			if got := s.Solve(tt.args.r); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Solve() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/day2/day2.go
+++ b/pkg/day2/day2.go
@@ -13,21 +13,10 @@ type Solver struct {
 	config *viper.Viper
 }
 
-func New(config *viper.Viper) solver.Solver {
+func New(config *viper.Viper) solver.Parts {
 	return &Solver{
 		config: config,
 	}
-}
-
-func (s *Solver) Solve(r io.ReadSeeker) []string {
-	s1 := s.PartOne(r)
-
-	_, err := r.Seek(0, io.SeekStart)
-	if err != nil {
-		return []string{err.Error(), ""}
-	}
-
-	return []string{s1, s.PartTwo(r)}
 }
 
 func (s Solver) PartOne(r io.ReadSeeker) string {

--- a/pkg/day2/day2_test.go
+++ b/pkg/day2/day2_test.go
@@ -155,7 +155,28 @@ func TestSolver_PartTwo(t *testing.T) {
 			input: 19690720,
 			want:  "100 \u2715 49 + 25 = 4925",
 		},
+		{
+			fields: fields{
+				config: viper.New(),
+			},
+			args: args{
+				r: strings.NewReader("1,12,2,0,0,0,0,0,0,0,0,0,0"),
+			},
+			input: 0,
+			want: "invalid instruction: 0",
+		},
+		{
+			fields: fields{
+				config: viper.New(),
+			},
+			args: args{
+				r: strings.NewReader("1,12,2,0,mio,99,0,0,0,0,0,0,0,0,0,0"),
+			},
+			input: 0,
+			want: "strconv.Atoi: parsing \"mio\": invalid syntax",
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Solver{
@@ -164,80 +185,6 @@ func TestSolver_PartTwo(t *testing.T) {
 			s.config.Set("part2.input", tt.input)
 			if got := s.PartTwo(tt.args.r); got != tt.want {
 				t.Errorf("PartTwo() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestSolver_Solve(t *testing.T) {
-	type fields struct {
-		config *viper.Viper
-	}
-	type args struct {
-		r io.ReadSeeker
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		input1 []int
-		input2 int
-		want   []string
-	}{
-		{
-			fields: fields{
-				config: viper.New(),
-			},
-			args: args{
-				r: strings.NewReader("2,0,0,0,99,3,0,0,0,0,0,0,2"),
-			},
-			input1: []int{12, 2},
-			input2: 9,
-			want:   []string{"4", "100 \u2715 5 + 5 = 505"},
-		},
-		{
-			fields: fields{
-				config: viper.New(),
-			},
-			args: args{
-				r: badreadseeker.New(strings.NewReader("2,0,0,0,99,3,0,0,0,0,0,0,2"), io.ErrShortBuffer, badreadseeker.Read),
-			},
-			input1: []int{12, 2},
-			input2: 9,
-			want:   []string{io.ErrShortBuffer.Error(), io.ErrShortBuffer.Error()},
-		},
-		{
-			fields: fields{
-				config: viper.New(),
-			},
-			args: args{
-				r: badreadseeker.New(strings.NewReader("2,0,0,0,99,3,0,0,0,0,0,0,2"), io.ErrShortBuffer, badreadseeker.Seek),
-			},
-			input1: []int{12, 2},
-			input2: 9,
-			want:   []string{io.ErrShortBuffer.Error(), ""},
-		},
-		{
-			fields: fields{
-				config: viper.New(),
-			},
-			args: args{
-				r: strings.NewReader("2,0,0,0,40,3,0,0,0,0,0,0,2"),
-			},
-			input1: []int{12, 2},
-			input2: 9,
-			want:   []string{"invalid instruction: 40", "invalid instruction: 40"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Solver{
-				config: tt.fields.config,
-			}
-			s.config.Set("part1.input", tt.input1)
-			s.config.Set("part2.input", tt.input2)
-			if got := s.Solve(tt.args.r); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Solve() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/day3/day3.go
+++ b/pkg/day3/day3.go
@@ -15,21 +15,10 @@ type Solver struct {
 	config *viper.Viper
 }
 
-func New(config *viper.Viper) solver.Solver {
+func New(config *viper.Viper) solver.Parts {
 	return &Solver{
 		config: config,
 	}
-}
-
-func (s *Solver) Solve(r io.ReadSeeker) []string {
-	s1 := s.PartOne(r)
-
-	_, err := r.Seek(0, io.SeekStart)
-	if err != nil {
-		return []string{err.Error(), ""}
-	}
-
-	return []string{s1, s.PartTwo(r)}
 }
 
 func (s *Solver) PartOne(r io.ReadSeeker) string {

--- a/pkg/day3/day3_test.go
+++ b/pkg/day3/day3_test.go
@@ -2,7 +2,6 @@ package day3
 
 import (
 	"github.com/somebadcode/adventofcode2019/internal/solver"
-	"github.com/somebadcode/adventofcode2019/internal/testdatafromfile"
 	"github.com/somebadcode/adventofcode2019/pkg/badreadseeker"
 	"github.com/somebadcode/adventofcode2019/pkg/vector"
 	"github.com/spf13/viper"
@@ -19,7 +18,7 @@ func TestNew(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want solver.Solver
+		want solver.Parts
 	}{
 		{
 			args: args{
@@ -138,7 +137,20 @@ func TestSolver_PartTwo(t *testing.T) {
 			},
 			want: vector.ErrInvalidDirection.Error(),
 		},
+		{
+			args: args{
+				r: badreadseeker.New(strings.NewReader("L90,U40"), io.ErrUnexpectedEOF, badreadseeker.Read),
+			},
+			want: io.ErrUnexpectedEOF.Error(),
+		},
+		{
+			args: args{
+				r: strings.NewReader("F87,R51"),
+			},
+			want: vector.ErrInvalidDirection.Error(),
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Solver{
@@ -146,68 +158,6 @@ func TestSolver_PartTwo(t *testing.T) {
 			}
 			if got := s.PartTwo(tt.args.r); got != tt.want {
 				t.Errorf("PartTwo() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestSolver_Solve(t *testing.T) {
-	type fields struct {
-		config *viper.Viper
-	}
-	type args struct {
-		r io.ReadSeeker
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   []string
-	}{
-		{
-			args: args{
-				r: strings.NewReader("R75,D30,R83,U83,L12,D49,R71,U7,L72\nU62,R66,U55,R34,D71,R55,D58,R83"),
-			},
-			want: []string{"159", "610"},
-		},
-		{
-			args: args{
-				r: strings.NewReader("R98,U47,R26,D63,R33,U87,L62,D20,R33,U53,R51\nU98,R91,D20,R16,D67,R40,U7,R15,U6,R7"),
-			},
-			want: []string{"135", "410"},
-		},
-		{
-			args: args{
-				r: testdatafromfile.From("day3.txt"),
-			},
-			want: []string{"1431", "48012"},
-		},
-		{
-			args: args{
-				r: badreadseeker.New(strings.NewReader("L90,U40"), io.ErrUnexpectedEOF, badreadseeker.Read),
-			},
-			want: []string{io.ErrUnexpectedEOF.Error(), io.ErrUnexpectedEOF.Error()},
-		},
-		{
-			args: args{
-				r: badreadseeker.New(strings.NewReader("L90,U40"), io.ErrUnexpectedEOF, badreadseeker.Seek),
-			},
-			want: []string{io.ErrUnexpectedEOF.Error(), ""},
-		},
-		{
-			args: args{
-				r: strings.NewReader("F87,R51"),
-			},
-			want: []string{vector.ErrInvalidDirection.Error(), vector.ErrInvalidDirection.Error()},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Solver{
-				config: tt.fields.config,
-			}
-			if got := s.Solve(tt.args.r); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Solve() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/day4/day4.go
+++ b/pkg/day4/day4.go
@@ -14,24 +14,13 @@ type Solver struct {
 	config *viper.Viper
 }
 
-func New(config *viper.Viper) solver.Solver {
+func New(config *viper.Viper) solver.Parts {
 	return &Solver{
 		config: config,
 	}
 }
 
-func (s *Solver) Solve(r io.ReadSeeker) []string {
-	s1 := s.PartOne(r)
-
-	_, err := r.Seek(0, io.SeekStart)
-	if err != nil {
-		return []string{err.Error(), ""}
-	}
-
-	return []string{s1, s.PartTwo(r)}
-}
-
-func (s *Solver) PartOne(r io.Reader) string {
+func (s Solver) PartOne(r io.ReadSeeker) string {
 	pair, err := parseRange(r)
 	if err != nil {
 		return err.Error()
@@ -48,7 +37,7 @@ func (s *Solver) PartOne(r io.Reader) string {
 	return strconv.FormatUint(counter, 10)
 }
 
-func (s *Solver) PartTwo(r io.Reader) string {
+func (s Solver) PartTwo(r io.ReadSeeker) string {
 	pair, err := parseRange(r)
 	if err != nil {
 		return err.Error()
@@ -65,12 +54,12 @@ func (s *Solver) PartTwo(r io.Reader) string {
 	return strconv.FormatUint(counter, 10)
 }
 
-func parseRange(r io.Reader) ([]int64, error) {
+func parseRange(r io.ReadSeeker) ([]int64, error) {
 	b := make([]byte, 50)
 	size, err := r.Read(b)
 	if err != nil {
 		return nil, err
-	} else if size <= 4 {
+	} else if size <= 3 {
 		return nil, errors.New("input too short")
 	}
 

--- a/pkg/day4/day4_test.go
+++ b/pkg/day4/day4_test.go
@@ -3,7 +3,6 @@ package day4
 import (
 	"bytes"
 	"github.com/somebadcode/adventofcode2019/internal/solver"
-	"github.com/somebadcode/adventofcode2019/internal/testdatafromfile"
 	"github.com/somebadcode/adventofcode2019/pkg/badreadseeker"
 	"github.com/spf13/viper"
 	"io"
@@ -19,7 +18,7 @@ func TestNew(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want solver.Solver
+		want solver.Parts
 	}{
 		{
 			args: args{
@@ -44,7 +43,7 @@ func TestSolver_PartOne(t *testing.T) {
 		config *viper.Viper
 	}
 	type args struct {
-		r io.Reader
+		r io.ReadSeeker
 	}
 	tests := []struct {
 		name   string
@@ -72,7 +71,7 @@ func TestSolver_PartOne(t *testing.T) {
 		},
 		{
 			args: args{
-				r: badreadseeker.New(strings.NewReader("100-900"), io.ErrShortBuffer, badreadseeker.Read),
+				r: badreadseeker.New(bytes.NewReader([]byte("100-900")), io.ErrShortBuffer, badreadseeker.Read),
 			},
 			want: io.ErrShortBuffer.Error(),
 		},
@@ -94,7 +93,7 @@ func TestSolver_PartTwo(t *testing.T) {
 		config *viper.Viper
 	}
 	type args struct {
-		r io.Reader
+		r io.ReadSeeker
 	}
 	tests := []struct {
 		name   string
@@ -134,80 +133,6 @@ func TestSolver_PartTwo(t *testing.T) {
 			}
 			if got := s.PartTwo(tt.args.r); got != tt.want {
 				t.Errorf("PartTwo() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestSolver_Solve(t *testing.T) {
-	type fields struct {
-		config *viper.Viper
-	}
-	type args struct {
-		r io.ReadSeeker
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   []string
-	}{
-		{
-			args: args{
-				r: strings.NewReader("12240-12999"),
-			},
-			want: []string{"70", "63"},
-		},
-		{
-			args: args{
-				r: strings.NewReader("1-3"),
-			},
-			want: []string{"input too short", "input too short"},
-		},
-		{
-			args: args{
-				r: bytes.NewReader([]byte{0xff, 0xfe, 0xfd, 0xfc, 0xfb}),
-			},
-			want: []string{"input is not a valid string", "input is not a valid string"},
-		},
-		{
-			args: args{
-				r: strings.NewReader("weeee"),
-			},
-			want: []string{"input is not a string with one separator '-'", "input is not a string with one separator '-'"},
-		},
-		{
-			args: args{
-				r: strings.NewReader("1-333"),
-			},
-			want: []string{"input pairs are too short", "input pairs are too short"},
-		},
-		{
-			args: args{
-				r: badreadseeker.New(strings.NewReader("100-900"), io.ErrShortBuffer, badreadseeker.Read),
-			},
-			want: []string{io.ErrShortBuffer.Error(), io.ErrShortBuffer.Error()},
-		},
-		{
-			args: args{
-				r: badreadseeker.New(strings.NewReader("100-900"), io.ErrShortBuffer, badreadseeker.Seek),
-			},
-			want: []string{io.ErrShortBuffer.Error(), ""},
-		},
-		{
-			args: args{
-				r: testdatafromfile.From("day4.txt"),
-			},
-			want: []string{"544", "334"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Solver{
-				config: tt.fields.config,
-			}
-			if got := s.Solve(tt.args.r); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Solve() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -301,7 +226,7 @@ func Test_validatePasswordTwo(t *testing.T) {
 
 func Test_parseRange(t *testing.T) {
 	type args struct {
-		r io.Reader
+		r io.ReadSeeker
 	}
 	tests := []struct {
 		name    string
@@ -336,7 +261,36 @@ func Test_parseRange(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			args: args{
+				r: strings.NewReader("100"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			args: args{
+				r: strings.NewReader("90000"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			args: args{
+				r: bytes.NewReader([]byte{0xff, 0xfe, 0xfd, 0xfc, 0xfb}),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			args: args{
+				r: strings.NewReader("19-1"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseRange(tt.args.r)


### PR DESCRIPTION
* Refactored the Solver interface into Parts that expects
  PartOne(r io.ReadSeeker) and PartTwo(r io.ReadSeeker) instead of
  just Solve(r io.ReadSeeker).
* Moved the seeking into the calling go routine.
* Removed Solve() and its unit tests from the day# packages.
* Moved tests into PartOne and PartTwo to keep coverage high.
  The net result is fewer tests with the same coverage.